### PR TITLE
fix empty post url 

### DIFF
--- a/lib/sw.js
+++ b/lib/sw.js
@@ -1,7 +1,7 @@
 var urlsToCache = [];
 
 {% for post in site.posts %}
-  urlsToCache.push("{{ post.permalink }}");
+  urlsToCache.push("{{ post.url }}");
 {% endfor %}
 
 {% for page in site.pages %}


### PR DESCRIPTION
Post URLs weren't adding to the cache in the latest version of Jekyll. 